### PR TITLE
Add agent name to chat stream

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -149,6 +149,18 @@ class MyEventHandler(AsyncAgentEventHandler[str]):
 
             stream_data = await get_message_and_annotations(self.agent_client, message)
             stream_data['type'] = "completed_message"
+
+            agent_name = None
+            if getattr(message, "agent_id", None):
+                try:
+                    agent_obj = await self.agent_client.agents.get_agent(message.agent_id)
+                    agent_name = agent_obj.name
+                except Exception as ex:  # pragma: no cover - best effort logging
+                    logger.warning(f"Unable to fetch agent name: {ex}")
+
+            if agent_name:
+                stream_data['agent_name'] = agent_name
+
             return serialize_sse_event(stream_data)
         except Exception as e:
             logger.error(f"Error in event handler for thread message: {e}", exc_info=True)

--- a/src/frontend/src/components/agents/AgentPreview.tsx
+++ b/src/frontend/src/components/agents/AgentPreview.tsx
@@ -307,6 +307,9 @@ export function AgentPreview({ agentDetails }: IAgentPreviewProps): ReactNode {
                 clearAssistantMessage(chatItem);
                 accumulatedContent = data.content;
                 annotations = data.annotations;
+                if (data.agent_name) {
+                  chatItem.agentName = data.agent_name;
+                }
                 isStreaming = false;
                 console.log(
                   "[ChatClient] Received completed message:",
@@ -339,7 +342,12 @@ export function AgentPreview({ agentDetails }: IAgentPreviewProps): ReactNode {
   };
 
   const createAssistantMessageDiv: () => IChatItem = () => {
-    var item = { id: crypto.randomUUID(), content: "", isAnswer: true, more: { time: new Date().toISOString() } };
+    var item: IChatItem = {
+      id: crypto.randomUUID(),
+      content: "",
+      isAnswer: true,
+      more: { time: new Date().toISOString() },
+    };
     setMessageList((prev) => [...prev, item]);
     return item;
   };

--- a/src/frontend/src/components/agents/AgentPreviewChatBot.tsx
+++ b/src/frontend/src/components/agents/AgentPreviewChatBot.tsx
@@ -44,7 +44,7 @@ export function AgentPreviewChatBot({
               <AssistantMessage
                 key={message.id}
                 agentLogo={agentLogo}
-                agentName={agentName}
+                agentName={message.agentName ?? agentName}
                 loadingState={
                   index === messageList.length - 1 && chatContext.isResponding
                     ? "loading"

--- a/src/frontend/src/components/agents/chatbot/types.ts
+++ b/src/frontend/src/components/agents/chatbot/types.ts
@@ -30,6 +30,7 @@ export interface IChatItem {
   role?: string;
   content: string;
   isAnswer?: boolean;
+  agentName?: string;
   annotations?: any[];
   fileReferences?: Map<string, any>;
   duration?: number;


### PR DESCRIPTION
## Summary
- include agent name in SSE stream data
- capture agent name in frontend chat state
- show per-message agent name in chat UI
- type updates for messages

## Testing
- `PYTHONPATH=src/api pytest tests/test_search_index_manager.py::TestSearchIndexManager::test_create_delete_mock -q`
- `pnpm build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684a5e256cf48329a157a53274d3a8d6