### PR TITLE
Fix agent name retrieval

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -153,7 +153,7 @@ class MyEventHandler(AsyncAgentEventHandler[str]):
             agent_name = None
             if getattr(message, "agent_id", None):
                 try:
-                    agent_obj = await self.agent_client.agents.get_agent(message.agent_id)
+                    agent_obj = await self.agent_client.get_agent(message.agent_id)
                     agent_name = agent_obj.name
                 except Exception as ex:  # pragma: no cover - best effort logging
                     logger.warning(f"Unable to fetch agent name: {ex}")


### PR DESCRIPTION
## Summary
- fetch agent name via AgentsClient.get_agent in `on_thread_message`
- include agent name in stream data when found

## Testing
- `PYTHONPATH=src/api pytest tests/test_search_index_manager.py -k test_create_delete_mock -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6e81a73883299c785e5f00fcefda